### PR TITLE
Fix org-side-tree-cursor-setup

### DIFF
--- a/org-side-tree.el
+++ b/org-side-tree.el
@@ -167,7 +167,7 @@ Prevents the side-tree window from closing when calling `delete-other-windows'."
 (defun org-side-tree-cursor-setup ()
   "Set `cursor-type' in tree-buffer, according to `org-side-tree-cursor'."
   (if (bound-and-true-p org-side-tree-cursor)
-      (setq-local cursor-type 'org-side-tree-cursor)
+      (setq-local cursor-type org-side-tree-cursor)
     (add-hook 'post-command-hook #'beginning-of-line nil t)
     (setq-local cursor-type nil)))
 


### PR DESCRIPTION
Removed a superfluous quote from org-side-tree-setup that broke the function.

The variable org-side-tree-cursor was quoted, so intead of setting cursor-type to the value of org-side-tree-cursor variable the function set the cursor-type to org-side-tree-cursor, which is not a valid value.